### PR TITLE
Better attach/detach object to/from robot, unify return format when planning fails, various bug fixes

### DIFF
--- a/src/curobo/geom/sdf/world_mesh.py
+++ b/src/curobo/geom/sdf/world_mesh.py
@@ -166,7 +166,7 @@ class WorldMeshCollision(WorldPrimitiveCollision):
             self._wp_mesh_cache[mesh.name] = self._load_mesh_to_warp(mesh)
             # return self._wp_mesh_cache[mesh.name]
         else:
-            log_warn("Object already in warp cache, using existing instance for: " + mesh.name)
+            log_info("Object already in warp cache, using existing instance for: " + mesh.name)
         return self._wp_mesh_cache[mesh.name]
 
     def _load_batch_mesh_to_warp(self, mesh_list: List[Mesh]) -> List:

--- a/src/curobo/rollout/arm_reacher.py
+++ b/src/curobo/rollout/arm_reacher.py
@@ -370,7 +370,7 @@ class ArmReacher(ArmBase, ArmReacherConfig):
                         current_pos = link_poses[k].position
                         current_quat = link_poses[k].quaternion
 
-                        pose_err, pos_err, quat_err = current_fn.forward_out_distance(
+                        pose_err, quat_err, pos_err = current_fn.forward_out_distance(
                             current_pos, current_quat, self._goal_buffer, k
                         )
                         pose_error.append(pose_err)

--- a/src/curobo/wrap/reacher/motion_gen.py
+++ b/src/curobo/wrap/reacher/motion_gen.py
@@ -4079,7 +4079,8 @@ class MotionGen(MotionGenConfig):
                     traj_result.rotation_error = traj_result.rotation_error[::solve_state.num_trajopt_seeds]
                     if traj_result.cspace_error is not None:
                         traj_result.cspace_error = traj_result.cspace_error[::solve_state.num_trajopt_seeds]
-                    traj_result.goalset_index = traj_result.goalset_index[::solve_state.num_trajopt_seeds]
+                    # traj_result.goalset_index is of shape (batch_size * num_seeds, interpolation_steps), wants (batch_size)
+                    traj_result.goalset_index = traj_result.goalset_index[::solve_state.num_trajopt_seeds, 0]
                     traj_result.path_buffer_last_tstep = traj_result.path_buffer_last_tstep[::solve_state.num_trajopt_seeds]
                     traj_result.solution = traj_result.solution[::solve_state.num_trajopt_seeds]
                     traj_result.optimized_dt = traj_result.optimized_dt[::solve_state.num_trajopt_seeds]

--- a/src/curobo/wrap/reacher/motion_gen.py
+++ b/src/curobo/wrap/reacher/motion_gen.py
@@ -4060,6 +4060,18 @@ class MotionGen(MotionGenConfig):
                     traj_result.solve_time = og_solve_time
                     if self.store_debug_in_result:
                         result.debug_info["finetune_trajopt_result"] = traj_result
+
+                    if solve_state.batch_size == 1:
+                        # traj_result.success is a tensor of length 1 already
+                        traj_result.interpolated_solution = traj_result.interpolated_solution.unsqueeze(0)
+                        traj_result.position_error = traj_result.position_error.unsqueeze(0)
+                        traj_result.rotation_error = traj_result.rotation_error.unsqueeze(0)
+                        if traj_result.cspace_error is not None:
+                            traj_result.cspace_error = traj_result.cspace_error.unsqueeze(0)
+                        traj_result.goalset_index = traj_result.goalset_index.unsqueeze(0)
+                        # traj_result.path_buffer_last_tstep is a python list of length 1 already
+                        traj_result.solution = traj_result.solution.unsqueeze(0)
+                        traj_result.optimized_dt = traj_result.optimized_dt.unsqueeze(0)
                 else:
                     traj_result.success = traj_result.success[::solve_state.num_trajopt_seeds]
                     traj_result.interpolated_solution = traj_result.interpolated_solution[::solve_state.num_trajopt_seeds]

--- a/src/curobo/wrap/reacher/motion_gen.py
+++ b/src/curobo/wrap/reacher/motion_gen.py
@@ -3239,8 +3239,8 @@ class MotionGen(MotionGenConfig):
         if plan_config.pose_cost_metric is not None:
             self.update_pose_cost_metric(PoseCostMetric.reset_metric())
 
-        if plan_config.time_dilation_factor is not None and torch.count_nonzero(result.success) > 0:
-            result.retime_trajectory(
+        if plan_config.time_dilation_factor is not None and torch.count_nonzero(best_result.success) > 0:
+            best_result.retime_trajectory(
                 plan_config.time_dilation_factor,
                 interpolation_kind=self.finetune_trajopt_solver.interpolation_type,
             )

--- a/src/curobo/wrap/reacher/motion_gen.py
+++ b/src/curobo/wrap/reacher/motion_gen.py
@@ -1367,9 +1367,16 @@ class MotionGenResult:
                 current_tensor = source_tensor.clone()
             else:
                 if isinstance(current_tensor, torch.Tensor) and isinstance(
-                    source_tensor, torch.Tensor
-                ):
-                    current_tensor[idx] = source_tensor[idx]
+                    source_tensor, torch.Tensor):
+                    # If the shapes are different, directly copy the tensor.
+                    if current_tensor.shape != source_tensor.shape:
+                        current_tensor = source_tensor.clone()
+                    # If they are zero-dimensional tensors, directly copy the value.
+                    elif len(current_tensor.shape) == 0:
+                        current_tensor[...] = source_tensor
+                    # Otherwise, copy the value at index.
+                    else:
+                        current_tensor[idx] = source_tensor[idx]
                 elif isinstance(current_tensor, JointState) and isinstance(
                     source_tensor, JointState
                 ):


### PR DESCRIPTION
Major
- Allow `scale` argument to scale the attached (grasped) object to avoid immediate contact
- Allow externally passing in `ee_pose` when calling `attach_objects_to_robot` so that we can attach to both `ee_link` and other `links` (e.g. left hand and right hand), not just `ee_link`.
- Fix `detach_object_from_robot`: re-enable collision meshes of the object once it's released from the grasp
- Fix wrong return order from `convergence_fn.forward_out_distance` in `ArmReacher`
- Fix zero-dim tensor for `copy_idx` function
- Fix `_plan_batch_attempts`: `retime_trajectory` is called on the `best_result`, not the last `result`.
- If IK or trajopt fails or if batch_size=1, always return `result.[tensor]` with a unified tensor shapes (e.g. `position_error`, `interpolated_solution`, `success`). For example, `result.position_error.shape` should always be `[B]`.

Minor
- Change `"Object already in warp cache..."` from warning to info